### PR TITLE
Add option to disable info logging - default true, add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+/.idea
+/vendor
+/node_modules
+composer.phar
+composer.lock
+phpunit.xml
+.phpunit.result.cache
+.DS_Store
+.env

--- a/config/console-over-http.php
+++ b/config/console-over-http.php
@@ -3,6 +3,7 @@
 return [
     'token' => env('CONSOLE_OVER_HTTP_TOKEN', null),
     'insecure' => env('CONSOLE_OVER_HTTP_INSECURE', false),
+    'debug_logs' => env('CONSOLE_OVER_HTTP_DEBUG_LOGS', true),
     'process' => [
         'timeout' => 3600,
     ],

--- a/src/ConsoleOverHttpController.php
+++ b/src/ConsoleOverHttpController.php
@@ -5,6 +5,7 @@ namespace Outl1ne\LaravelConsoleOverHttp;
 use Illuminate\Routing\Controller as BaseController;
 use Illuminate\Http\Request;
 use Symfony\Component\Process\Process;
+use Illuminate\Support\Facades\Log;
 
 class ConsoleOverHttpController extends BaseController
 {
@@ -20,13 +21,14 @@ class ConsoleOverHttpController extends BaseController
         $process->start();
 
         echo '<html><body style="background:#000;font-family:monospace;">';
+        $debugLogsEnabled = config('console-over-http.debug_logs');
 
         foreach ($process as $type => $data) {
             if ($process::OUT === $type) {
-                \Log::info($data);
+                if($debugLogsEnabled) Log::info($data);
                 echo "\n<span style='color:#ccc'>" . $data . "</span><br />";
             } else {
-                \Log::error($data);
+                Log::error($data);
                 echo "\n<span style='color:red'>" . $data . "</span><br />";
             }
         }

--- a/src/ConsoleOverHttpController.php
+++ b/src/ConsoleOverHttpController.php
@@ -25,7 +25,7 @@ class ConsoleOverHttpController extends BaseController
 
         foreach ($process as $type => $data) {
             if ($process::OUT === $type) {
-                if($debugLogsEnabled) Log::info($data);
+                if ($debugLogsEnabled) Log::info($data);
                 echo "\n<span style='color:#ccc'>" . $data . "</span><br />";
             } else {
                 Log::error($data);


### PR DESCRIPTION
```
Log::info($data);
```

Is creating a lot of noise for no particular reason, add the ability to disable it. Error logs will still always be logged.

Also .gitignore for local development.